### PR TITLE
createOpenstackVM: use the HDD pool for gating VMs

### DIFF
--- a/vars/createOpenstackVMs.groovy
+++ b/vars/createOpenstackVMs.groovy
@@ -140,7 +140,7 @@ def call(String namePrefix, String image="centos7", String flavor="m1.xlarge", I
     if (bySnapshot == false ) {
 
       rootVolumeUuid = sh(returnStdout: true,
-      script: "openstack volume create --os-cloud ${provider} --image ${imageUuid} --bootable --type rbd2 --size 160 -f value -c id ${vmName}").trim()
+      script: "openstack volume create --os-cloud ${provider} --image ${imageUuid} --bootable --type rbd1 --size 160 -f value -c id ${vmName}").trim()
       println("rootVolumeUuid: ${rootVolumeUuid}")
 
       bdm = "--block-device source=volume,id=${rootVolumeUuid},dest=volume,size=160,shutdown=${bdmShutdown},bootindex=0"
@@ -148,7 +148,7 @@ def call(String namePrefix, String image="centos7", String flavor="m1.xlarge", I
         volName = vmName + "-vol-" + (index+1).toString()
 
         println("Creating volume ${volName}...")
-        volUuid = sh(returnStdout: true,script: "openstack volume create --os-cloud ${provider} --type rbd2 --size ${it} -f value -c id ${volName}").trim()
+        volUuid = sh(returnStdout: true,script: "openstack volume create --os-cloud ${provider} --type rbd1 --size ${it} -f value -c id ${volName}").trim()
 
         bootindex = index+1
         bdm += " --block-device source=volume,id=${volUuid},dest=volume,size=${it},shutdown=${bdmShutdown},bootindex=${bootindex}"


### PR DESCRIPTION
용량 및 안정성 이슈가 있는 SSD Pool 대신 HDD Pool 사용하여 Gating VM용 볼륨 생성하도록 변경하는 내용입니다.