### PR TITLE
createOpenstackVMs: use rbd2 (ssd) volume type for OS volume

### DIFF
--- a/vars/createOpenstackVMs.groovy
+++ b/vars/createOpenstackVMs.groovy
@@ -140,7 +140,7 @@ def call(String namePrefix, String image="centos7", String flavor="m1.xlarge", I
     if (bySnapshot == false ) {
 
       rootVolumeUuid = sh(returnStdout: true,
-      script: "openstack volume create --os-cloud ${provider} --image ${imageUuid} --bootable --type ${volType} --size 160 -f value -c id ${vmName}").trim()
+      script: "openstack volume create --os-cloud ${provider} --image ${imageUuid} --bootable --type rbd2 --size 160 -f value -c id ${vmName}").trim()
       println("rootVolumeUuid: ${rootVolumeUuid}")
 
       bdm = "--block-device source=volume,id=${rootVolumeUuid},dest=volume,size=160,shutdown=${bdmShutdown},bootindex=0"


### PR DESCRIPTION
판교 개발 환경의 스토리지 용량 이슈가 있어 아래와 같은 변경 사항을 적용했었습니다.
- VM의 OS 볼륨 및 추가 확장 볼륨 모두 rbd1 (HDD) 타입으로 생성하도록 변경
- OS 볼륨 및 추가 확장 볼륨 타입을 설정 가능하도록 변경: 기본값은 rbd1 (HDD)

rbd1 볼륨 타입 사용 시 성능 문제로 argo 초기화 실패가 발생하고 etcd 반응이 매우^100 느린 이슈가 존재하지만 기존처럼 전체 볼륨을 rbd2에서 생성하는 것은 용량 소비가 크기 때문에 다음과 같이 수정해 보았습니다.
- VM의 OS 볼륨은 rbd2 (SSD) 타입으로 생성
- 확장 볼륨은 설정 가능하며 rbd1 (HDD) 타입을 기본 사용